### PR TITLE
Proposal ENS 5.22

### DIFF
--- a/dao/ens/ens.t.sol
+++ b/dao/ens/ens.t.sol
@@ -68,7 +68,7 @@ abstract contract ENS_Governance is Test, IDAO {
         vm.roll(block.number + 1);
 
         assertGt(ensToken.getVotes(voter), governor.quorum(block.number - 1));
-        assertGt(ensToken.getVotes(proposer), governor.proposalThreshold());
+        assertGe(ensToken.getVotes(proposer), governor.proposalThreshold());
 
         // Creating a proposal that gives a proposer role to
         (

--- a/dao/ens/interfaces/ITokenStreamingEP5-22.sol
+++ b/dao/ens/interfaces/ITokenStreamingEP5-22.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.4;
+
+interface ITokenStreamingEP5_22 {
+    event Claimed(address indexed recipient, uint256 amount);
+    event Configured(address token, address tokenSender, uint256 startTime, uint256 endTime, uint256 streamingRate);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    function claim(address recipient, uint256 amount) external;
+    function claimableBalance() external view returns (uint256);
+    function endTime() external view returns (uint256);
+    function owner() external view returns (address);
+    function renounceOwnership() external;
+    function setEndTime(uint256 _endTime) external;
+    function startTime() external view returns (uint256);
+    function streamingRate() external view returns (uint256);
+    function token() external view returns (address);
+    function tokenSender() external view returns (address);
+    function totalClaimed() external view returns (uint256);
+    function transferOwnership(address newOwner) external;
+}

--- a/proposals/ens-ep-5-22/proposal.t.sol
+++ b/proposals/ens-ep-5-22/proposal.t.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import { Test } from "@forge-std/src/Test.sol";
+import { console2 } from "@forge-std/src/console2.sol";
+
+import { IToken } from "@ens/interfaces/IToken.sol";
+import { IGovernor } from "@ens/interfaces/IGovernor.sol";
+import { ITimelock } from "@ens/interfaces/ITimelock.sol";
+import { ITimelock } from "@ens/interfaces/ITimelock.sol";
+import { ITokenStreamingEP5_22 } from "@ens/interfaces/ITokenStreamingEP5-22.sol";
+import { IERC20 } from "@contracts/token/interfaces/IERC20.sol";
+
+import { ENS_Governance } from "@ens/ens.t.sol";
+
+// https://www.tally.xyz/gov/ens/proposal/33504840096777976512510989921427323867039135570342563123194157971712476988820
+
+contract Proposal_ENS_EP_5_22_Test is ENS_Governance {
+    uint256 timelockUSDCbalanceBefore;
+    uint256 expectedUSDCtransfer = 15_075_331_200;
+    uint256 timelockUSDCbalanceAfter;
+    address streamingContractAdmin = 0xb8c2C29ee19D8307cb7255e1Cd9CbDE883A267d5; // nick.eth
+    address receiver = 0x690F0581eCecCf8389c223170778cD9D029606F2; // ENS Labs
+
+    ITokenStreamingEP5_22 streamingContract = ITokenStreamingEP5_22(0x05C8f60e24FcDd9B8Ed7bB85dF8164C41cB4DA16); // stream
+        // contract
+    IERC20 USDC = IERC20(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+
+    function _selectFork() public override {
+        vm.createSelectFork({ blockNumber: 21_086_802, urlOrAlias: "mainnet" });
+    }
+
+    function _proposer() public view override returns (address) {
+        return 0xE3919F3f971C4589089DaA930aaFa81B8A27b406;
+    }
+
+    function _beforePropose() public override {
+        timelockUSDCbalanceBefore = USDC.balanceOf(address(timelock));
+    }
+
+    function _generateCallData()
+        public
+        override
+        returns (
+            address[] memory targets,
+            uint256[] memory values,
+            string[] memory signatures,
+            bytes[] memory calldatas,
+            string memory description
+        )
+    {
+        uint256 items = 1;
+
+        targets = new address[](items);
+        targets[0] = address(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+
+        values = new uint256[](items);
+        values[0] = 0;
+
+        calldatas = new bytes[](items);
+        calldatas[0] =
+            hex"095ea7b300000000000000000000000005c8f60e24fcdd9b8ed7bb85df8164c41cb4da16ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
+        bytes memory expectedCalldata =
+            abi.encodeWithSelector(USDC.approve.selector, address(streamingContract), type(uint256).max);
+
+        assertEq(calldatas[0], expectedCalldata);
+
+        return (targets, values, signatures, calldatas, "");
+    }
+
+    function _afterExecution() public override {
+        console2.log("Claimable balance", streamingContract.claimableBalance());
+        console2.log("Total claimed", streamingContract.totalClaimed());
+
+        vm.warp(streamingContract.startTime() + 1 days);
+
+        console2.log("Claimable balance", streamingContract.claimableBalance());
+        console2.log("Total claimed", streamingContract.totalClaimed());
+
+        vm.startPrank(streamingContractAdmin);
+        streamingContract.claim(receiver, streamingContract.claimableBalance());
+        vm.stopPrank();
+
+        timelockUSDCbalanceAfter = USDC.balanceOf(address(timelock));
+        assertEq(timelockUSDCbalanceBefore, timelockUSDCbalanceAfter + expectedUSDCtransfer);
+        assertNotEq(timelockUSDCbalanceAfter, timelockUSDCbalanceBefore);
+    }
+}


### PR DESCRIPTION
[Proposal link on forum](https://discuss.ens.domains/t/ep-5-22-ensv2-development-funding-request/19762)

The executable code gives an "infinite" USDC approval of spending from the ENS DAO to the streaming contract. Therefore, we needed to analyze the streaming contract to understand logic and parameters.

- Streaming contract parameters checked
	- Streaming rate is $0.174483, which matches the proposed increase of streaming.
	- Streaming start is 1735689600 (in UNIX timestamp), which means 1 Jan 2025 00:00 UTC.
	- The end time is set to "infinite" and can only be set by the DAO, 
	
How can the steam be canceled?
- Change USDC approval
- DAO can change end time

For the streaming to run smoothly, the DAO needs to make sure that there is USDC in the treasury.

nick.eth is the admin of the streaming contract, and the claim function can only be called by the owner.